### PR TITLE
feat: add human input forms

### DIFF
--- a/src/mcp_agent_ts/app.ts
+++ b/src/mcp_agent_ts/app.ts
@@ -2,12 +2,11 @@
 
 // This file is a conversion of the Python app.py to TypeScript, maintaining original functionality.
 
+import { HumanInputCallback } from './humanInput/types';
+export type { HumanInputCallback } from './humanInput/types';
+
 export interface Settings {
   // Placeholder for configuration settings
-}
-
-export interface HumanInputCallback {
-  (prompt: string): Promise<string>;
 }
 
 export interface SignalWaitCallback {

--- a/src/mcp_agent_ts/context.ts
+++ b/src/mcp_agent_ts/context.ts
@@ -3,7 +3,8 @@
 // This file provides context capabilities similar to those in the Python context.py
 
 import { Settings, loadSettings } from './config';
-import { HumanInputCallback, ServerSession } from './app';
+import { ServerSession } from './app';
+import { HumanInputCallback } from './humanInput/types';
 import { Executor, createExecutor } from './executor/executor';
 import { TaskRegistry, createTaskRegistry } from './executor/taskRegistry';
 

--- a/src/mcp_agent_ts/executor/workflow.ts
+++ b/src/mcp_agent_ts/executor/workflow.ts
@@ -2,6 +2,14 @@
 
 // This file provides workflow capabilities similar to those in the Python executor/workflow.py
 import { Executor } from './executor';
+import {
+  ElicitationForm,
+  FormResponse,
+  HumanInputCallback,
+  HumanInputRequest,
+  HumanInputResponse,
+} from '../humanInput/types';
+import { consoleInputCallback } from '../humanInput/handler';
 
 /**
  * Represents an application-like object that provides an executor.
@@ -35,6 +43,23 @@ export abstract class BaseWorkflow implements Workflow {
     this.executor = app.executor;
     this.name = name || this.constructor.name;
     this.description = description;
+  }
+
+  private getHumanInputHandler(): HumanInputCallback {
+    const ctx = (this.app as any)?.getContext?.();
+    return ctx?.humanInputHandler ?? consoleInputCallback;
+  }
+
+  protected async humanInput(
+    prompt: HumanInputRequest
+  ): Promise<HumanInputResponse> {
+    const handler = this.getHumanInputHandler();
+    return handler(prompt);
+  }
+
+  protected async elicitForm(form: ElicitationForm): Promise<FormResponse> {
+    const result = await this.humanInput(form);
+    return typeof result === 'string' ? { value: result } : result;
   }
 
   /**

--- a/src/mcp_agent_ts/humanInput/elicitation_form.ts
+++ b/src/mcp_agent_ts/humanInput/elicitation_form.ts
@@ -1,0 +1,10 @@
+import { ElicitationForm, FormResponse, HumanInputCallback } from './types';
+import { consoleInputCallback } from './handler';
+
+export async function runElicitationForm(
+  form: ElicitationForm,
+  callback: HumanInputCallback = consoleInputCallback
+): Promise<FormResponse> {
+  const result = await callback(form);
+  return typeof result === 'string' ? { value: result } : result;
+}

--- a/src/mcp_agent_ts/humanInput/forms.ts
+++ b/src/mcp_agent_ts/humanInput/forms.ts
@@ -1,0 +1,18 @@
+import { FormField } from './types';
+
+export function textField(name: string, label: string, required = false): FormField {
+  return { name, label, type: 'text', required };
+}
+
+export function textareaField(name: string, label: string, required = false): FormField {
+  return { name, label, type: 'textarea', required };
+}
+
+export function selectField(
+  name: string,
+  label: string,
+  options: string[],
+  required = false
+): FormField {
+  return { name, label, type: 'select', options, required };
+}

--- a/src/mcp_agent_ts/humanInput/handler.ts
+++ b/src/mcp_agent_ts/humanInput/handler.ts
@@ -5,23 +5,43 @@
 
 import readline from 'node:readline/promises';
 import { stdin as input, stdout as output } from 'node:process';
-import { HumanInputCallback } from '../app';
+import {
+  FormResponse,
+  HumanInputCallback,
+  HumanInputRequest,
+  HumanInputResponse,
+} from './types';
 
 /**
- * The active callback used to retrieve human input.  Defaults to a readline
- * implementation that prints the prompt and resolves the user’s response.
+ * The active callback used to retrieve human input. Defaults to a readline
+ * implementation that prints prompts and resolves the user’s responses.
  */
-let activeCallback: HumanInputCallback = async (prompt: string) => {
-  const rl = readline.createInterface({ input, output });
-  const answer = await rl.question(prompt);
-  rl.close();
-  return answer;
+let activeCallback: HumanInputCallback = async (
+  prompt: HumanInputRequest
+): Promise<HumanInputResponse> => {
+  if (typeof prompt === 'string') {
+    const rl = readline.createInterface({ input, output });
+    const answer = await rl.question(prompt);
+    rl.close();
+    return answer;
+  }
+
+  const responses: FormResponse = {};
+  for (const field of prompt.fields) {
+    const rl = readline.createInterface({ input, output });
+    const answer = await rl.question(`${field.label}: `);
+    rl.close();
+    responses[field.name] = answer;
+  }
+  return responses;
 };
 
 /**
  * Obtain input from the current human–input callback.
  */
-export async function consoleInputCallback(prompt: string): Promise<string> {
+export async function consoleInputCallback(
+  prompt: HumanInputRequest
+): Promise<HumanInputResponse> {
   return activeCallback(prompt);
 }
 

--- a/src/mcp_agent_ts/humanInput/types.ts
+++ b/src/mcp_agent_ts/humanInput/types.ts
@@ -1,0 +1,23 @@
+export type FieldType = 'text' | 'textarea' | 'select';
+
+export interface FormField {
+  name: string;
+  label: string;
+  type: FieldType;
+  required?: boolean;
+  options?: string[];
+}
+
+export interface ElicitationForm {
+  title?: string;
+  fields: FormField[];
+}
+
+export type FormResponse = Record<string, string>;
+
+export type HumanInputRequest = string | ElicitationForm;
+export type HumanInputResponse = string | FormResponse;
+
+export interface HumanInputCallback {
+  (prompt: HumanInputRequest): Promise<HumanInputResponse>;
+}

--- a/src/mcp_agent_ts/index.ts
+++ b/src/mcp_agent_ts/index.ts
@@ -9,3 +9,6 @@ export * from './executor/workflow';
 export * from './executor/taskRegistry';
 export * from './context';
 export * from './humanInput/handler';
+export * from './humanInput/forms';
+export * from './humanInput/types';
+export * from './humanInput/elicitation_form';

--- a/tests/unit/mcp_agent_ts/humanInput/elicitation_form.test.ts
+++ b/tests/unit/mcp_agent_ts/humanInput/elicitation_form.test.ts
@@ -1,0 +1,17 @@
+import { runElicitationForm } from '../../../../src/mcp_agent_ts/humanInput/elicitation_form';
+import { textField } from '../../../../src/mcp_agent_ts/humanInput/forms';
+import { ElicitationForm, HumanInputCallback } from '../../../../src/mcp_agent_ts/humanInput/types';
+
+describe('Elicitation form', () => {
+  it('collects responses using provided callback', async () => {
+    const form: ElicitationForm = {
+      title: 'Test',
+      fields: [textField('name', 'Name'), textField('age', 'Age')],
+    };
+
+    const callback: HumanInputCallback = async () => ({ name: 'Alice', age: '30' });
+
+    const result = await runElicitationForm(form, callback);
+    expect(result).toEqual({ name: 'Alice', age: '30' });
+  });
+});


### PR DESCRIPTION
## Summary
- add form field and callback types for structured human input
- provide helper functions and elicitation form runner
- allow workflows to request human input through new interfaces

## Testing
- `npm test` *(fails: Test Suites: 14 failed, 26 passed)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6898265452008325a84f560852dbd0ff