### PR TITLE
feat: add mcp prompt and sampling utilities

### DIFF
--- a/src/mcp/index.ts
+++ b/src/mcp/index.ts
@@ -1,0 +1,5 @@
+export * from './prompt_message_multipart';
+export * from './prompt_render';
+export * from './prompt_serialization';
+export * from './sampling';
+export * from './resource_utils';

--- a/src/mcp/prompt_message_multipart.ts
+++ b/src/mcp/prompt_message_multipart.ts
@@ -1,0 +1,82 @@
+import { PromptMessage, TextContent, ImageContent, EmbeddedResource } from '../core/mcpContent';
+
+export type MultipartContent = TextContent | ImageContent | EmbeddedResource;
+
+export interface GetPromptResult {
+  messages: PromptMessage[];
+}
+
+export class PromptMessageMultipart {
+  role: string;
+  content: MultipartContent[];
+
+  constructor(role: string, content: MultipartContent[] = []) {
+    this.role = role;
+    this.content = content;
+  }
+
+  /**
+   * Convert a list of PromptMessages into a list of PromptMessageMultipart
+   * by merging consecutive messages with the same role.
+   */
+  static toMultipart(messages: PromptMessage[]): PromptMessageMultipart[] {
+    const result: PromptMessageMultipart[] = [];
+    let current: PromptMessageMultipart | null = null;
+
+    for (const msg of messages) {
+      if (current && current.role === msg.role) {
+        current.content.push(msg.content as MultipartContent);
+      } else {
+        if (current) result.push(current);
+        current = new PromptMessageMultipart(msg.role, [msg.content as MultipartContent]);
+      }
+    }
+
+    if (current) result.push(current);
+    return result;
+  }
+
+  /**
+   * Convert this multipart message back into a sequence of PromptMessages.
+   */
+  fromMultipart(): PromptMessage[] {
+    return this.content.map((c) => ({ role: this.role, content: c }));
+  }
+
+  /**
+   * Parse a GetPromptResult into multipart messages.
+   */
+  static parseGetPromptResult(result: GetPromptResult): PromptMessageMultipart[] {
+    return result && result.messages ? this.toMultipart(result.messages) : [];
+  }
+
+  /**
+   * Convenience method to handle optional GetPromptResult objects.
+   */
+  static fromGetPromptResult(result?: GetPromptResult | null): PromptMessageMultipart[] {
+    if (!result || !result.messages || result.messages.length === 0) {
+      return [];
+    }
+    return this.toMultipart(result.messages);
+  }
+
+  /**
+   * Return the last text content in this multipart message, or "<no text>" if none.
+   */
+  lastText(): string {
+    for (let i = this.content.length - 1; i >= 0; i--) {
+      const part = this.content[i];
+      if ((part as TextContent).type === 'text') {
+        return (part as TextContent).text;
+      }
+    }
+    return '<no text>';
+  }
+
+  /**
+   * Append a new TextContent item to this multipart message.
+   */
+  addText(text: string): void {
+    this.content.push({ type: 'text', text });
+  }
+}

--- a/src/mcp/prompt_render.ts
+++ b/src/mcp/prompt_render.ts
@@ -1,0 +1,40 @@
+import { PromptMessageMultipart, MultipartContent } from './prompt_message_multipart';
+import { TextContent, ImageContent, EmbeddedResource } from '../core/mcpContent';
+
+/**
+ * Render a PromptMessageMultipart into a human-readable string.
+ */
+export function renderMultipartMessage(message: PromptMessageMultipart): string {
+  const lines: string[] = [];
+
+  for (const part of message.content) {
+    if ((part as TextContent).type === 'text') {
+      lines.push((part as TextContent).text);
+      continue;
+    }
+
+    if ((part as ImageContent).type === 'image') {
+      const img = part as ImageContent;
+      lines.push(`[IMAGE: ${img.mimeType} (${img.data.length} bytes)]`);
+      continue;
+    }
+
+    if ((part as EmbeddedResource).type === 'resource') {
+      const res = (part as EmbeddedResource).resource as any;
+      if ('text' in res && typeof res.text === 'string') {
+        const preview = res.text.length > 300 ? res.text.slice(0, 300) + '...' : res.text;
+        lines.push(
+          `[EMBEDDED TEXT RESOURCE: ${res.mimeType || 'unknown'} ${res.uri} (${res.text.length} chars)]\n${preview}`,
+        );
+      } else {
+        const data = res.blob || res.data || '';
+        lines.push(
+          `[EMBEDDED BLOB RESOURCE: ${res.mimeType || 'unknown'} ${res.uri} (${data.length} bytes)]`,
+        );
+      }
+      continue;
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/src/mcp/prompt_serialization.ts
+++ b/src/mcp/prompt_serialization.ts
@@ -1,0 +1,46 @@
+import { PromptMessage, TextContent, EmbeddedResource } from '../core/mcpContent';
+import { PromptMessageMultipart } from './prompt_message_multipart';
+
+/** Serialize multipart messages to JSON string. */
+export function multipartMessagesToJson(messages: PromptMessageMultipart[]): string {
+  return JSON.stringify(messages);
+}
+
+/** Deserialize multipart messages from JSON string. */
+export function jsonToMultipartMessages(jsonStr: string): PromptMessageMultipart[] {
+  const data = JSON.parse(jsonStr) as Array<{ role: string; content: any[] }>;
+  return data.map((m) => new PromptMessageMultipart(m.role, m.content as any));
+}
+
+/**
+ * Convert multipart messages into a simple delimited text format.
+ * Each role section is prefixed with ---ROLE and text content is joined with blank lines.
+ * Embedded resources are emitted as JSON after a ---RESOURCE delimiter.
+ */
+export function multipartMessagesToDelimitedFormat(messages: PromptMessageMultipart[]): string[] {
+  const result: string[] = [];
+
+  for (const msg of messages) {
+    result.push(`---${msg.role.toUpperCase()}`);
+
+    const textParts: string[] = [];
+    const resourceParts: EmbeddedResource[] = [];
+
+    for (const part of msg.content) {
+      if ((part as TextContent).type === 'text') {
+        textParts.push((part as TextContent).text);
+      } else if ((part as EmbeddedResource).type === 'resource') {
+        resourceParts.push(part as EmbeddedResource);
+      }
+    }
+
+    result.push(textParts.join('\n\n'));
+
+    for (const res of resourceParts) {
+      result.push('---RESOURCE');
+      result.push(JSON.stringify(res));
+    }
+  }
+
+  return result;
+}

--- a/src/mcp/resource_utils.ts
+++ b/src/mcp/resource_utils.ts
@@ -1,0 +1,15 @@
+import { EmbeddedResource, ImageContent, TextResourceContents, BlobResourceContents } from '../core/mcpContent';
+
+export function createTextResource(uri: string, text: string, mimeType: string): EmbeddedResource {
+  const resource: TextResourceContents = { uri, text, mimeType };
+  return { type: 'resource', resource };
+}
+
+export function createBlobResource(uri: string, blob: string, mimeType: string): EmbeddedResource {
+  const resource: BlobResourceContents = { uri, blob, mimeType };
+  return { type: 'resource', resource };
+}
+
+export function createImageContent(data: string, mimeType: string): ImageContent {
+  return { type: 'image', data, mimeType };
+}

--- a/src/mcp/sampling.ts
+++ b/src/mcp/sampling.ts
@@ -1,0 +1,62 @@
+/**
+ * Minimal types for sampling agent configuration.
+ */
+export interface TextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface SamplingMessage {
+  role: string;
+  content: TextContent;
+}
+
+export interface CreateMessageRequestParams {
+  maxTokens?: number;
+  messages?: SamplingMessage[];
+  systemPrompt?: string;
+}
+
+export interface AgentConfig {
+  name: string;
+  instruction: string;
+  servers: string[];
+}
+
+/**
+ * Build a basic AgentConfig for sampling requests.
+ */
+export function samplingAgentConfig(params?: CreateMessageRequestParams | null): AgentConfig {
+  const instruction = params?.systemPrompt !== undefined ? params.systemPrompt : 'You are a helpful AI Agent.';
+  return {
+    name: 'sampling_agent',
+    instruction,
+    servers: [],
+  };
+}
+
+/**
+ * Simple helpers to manage connections to MCP servers. These are lightweight
+ * wrappers around expected connect/close methods, making it easy to ensure
+ * servers are opened and closed as needed.
+ */
+export interface MCPServerConnection {
+  isConnected?: () => boolean;
+  connect: () => Promise<void>;
+  close: () => Promise<void>;
+}
+
+export async function ensureConnected(server: MCPServerConnection): Promise<void> {
+  if (server.isConnected && server.isConnected()) {
+    return;
+  }
+  await server.connect();
+}
+
+export async function disconnect(server: MCPServerConnection): Promise<void> {
+  try {
+    await server.close();
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary
- add PromptMessageMultipart utilities for multipart prompt conversions
- support rendering and serialization of multipart messages
- provide sampling agent config and MCP server connection helpers
- add helpers for constructing resources and image content

## Testing
- `npm test` *(fails: Cannot invoke an object which is possibly 'undefined')*

------
https://chatgpt.com/codex/tasks/task_e_6898266269608325af9f591cd69ea683